### PR TITLE
ensure the correct nonce tx is captured, go backwards until first block

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -29,9 +29,11 @@ const Search = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    const firstBlockID = await getLatestBlockID();
     const result = await callClient(searchValue).then(setLoading(true));
+    window.firstTransactionHash = result.transaction.hash;
+    const firstBlockID = result.transaction_outcome.block_hash;
     const requestNonce = getFormattedNonce(result);
+    window.nonce = requestNonce;
 
     console.log('Request Nonce: ', requestNonce);
 

--- a/src/services/contractUtils.js
+++ b/src/services/contractUtils.js
@@ -44,7 +44,6 @@ export async function getTransactions(firstBlock, lastBlock){
     currentBlock = await getBlockByID(blockHash);
     blockArr.push(currentBlock.header.hash);
     blockHash = currentBlock.header.prev_hash;
-    console.log('in here');
   } while (blockHash !== firstBlock)
 
   // returns block details based on ID's in array
@@ -73,7 +72,7 @@ export async function getTransactions(firstBlock, lastBlock){
   const transactions = []
   chunkDetails.map(chunk => {
     chunk.transactions?.map(txs => {
-      if(txs.signer_id.includes(`oracle-node.${nearAcct}`)) {
+      if (txs.signer_id.includes(`oracle-node.${nearAcct}`)) {
         transactions.push(txs);
       }
     });


### PR DESCRIPTION
fixes #46 

A couple things in here. Right after we call `get_token_price` it returns the nonce to us. This will be important, so I am doing the cheesy global variable thing of setting it to `window.nonce`
Also, the payload it gives us back has the transaction hash, so we don't need to look for it later. Set that to `window.firstTransactionHash`
So when we go to create an Explorer link for the first step, we can use this.

Then added a `do while` to "go backwards" until we reach the first block, looking for the `fulfill_request` call.
(This uses `.prev_hash`)

Lastly, modified the `reduce` such that it'll base64 decode the arguments and ensure that the transactions we care about are the ones with `window.nonce` in the arguments. Otherwise, when multiple people use this demo app at the same time, they will find multiple `fulfill_request` calls, just not for their nonce. In order to create the correct Explorer link, we must dig into the arguments.