### PR TITLE
window.nearSteps contains step 2 and 6 receipts if we want to display

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -11,7 +11,9 @@ import {
   getFormattedNonce,
   getLatestBlockID,
   getTransactions,
-  getReceivedVal } from '../services/contractUtils'
+  getReceivedVal,
+  getTransaction,
+  getReceiptsFromAccountPrefix } from '../services/contractUtils'
 import { useDiagramDispatch } from './DiagramState'
 import StyledButton from './StyledButton';
 
@@ -31,6 +33,9 @@ const Search = () => {
     e.preventDefault()
     const result = await callClient(searchValue).then(setLoading(true));
     window.firstTransactionHash = result.transaction.hash;
+    const txObj = await getTransaction(window.firstTransactionHash, 'client');
+    await getReceiptsFromAccountPrefix(txObj, 'oracle', 2)
+    window.firstTransaction = result.transaction;
     const firstBlockID = result.transaction_outcome.block_hash;
     const requestNonce = getFormattedNonce(result);
     window.nonce = requestNonce;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import App from './App'
 import { initContract } from './services/utils'
 import {  } from './services/contractUtils'
 
+window.nearSteps = []
 window.nearInitPromise = initContract()
   .then(() => {
     ReactDOM.render(

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,7 +1,4 @@
 import { connect, keyStores, KeyPair } from 'near-api-js'
-const nearAcct = process.env.NEAR_ACCT
-import { getBlockByID } from './contractUtils';
-import bs58 from 'bs58'
 
 //configuration for connection to NEAR
 const nearConfig = {


### PR DESCRIPTION
Using the same cheesy approach of window.variable, I filtered out 2 receipts that we could show if we want for Step 2 and Step 6. While we can't have an explorer link, it might be neat to show the actual logs that showed up.

Probably all this stuff would be better if it were handled _not_ using `window.` for everything, but wanted to put it there for quick iteration.