### PR TITLE
start script: remove env-cmd, add --no-cache to parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "license": "UNLICENSED",
   "scripts": {
-    "start": "echo The app is starting! It will automatically open in your browser when ready && env-cmd -f ./neardev/dev-account.env parcel src/index.html --open",
+    "start": "echo The app is starting! It will automatically open in your browser when ready && parcel src/index.html --open --no-cache",
     "build:web": "parcel build src/index.html --public-url ./",
     "test": "jest test --runInBand",
     "deploy": "yarn build:web && gh-pages -d dist/"


### PR DESCRIPTION
As we're moving to using environment variables, best to remove the env-cmd thing as it's difficult to get that directory in a project