### PR TITLE
Show helpful message if user clones without setting up environment variables

### DIFF
--- a/src/components/DiagramOverlay.jsx
+++ b/src/components/DiagramOverlay.jsx
@@ -31,7 +31,7 @@ const DiagramOverlay = () => {
                 </p>
                 {
                     isMissingEnvVars ?
-                      <p className={'warning'}><strong>Warning</strong>: thank you for the interest in this project. <span className={'warning-text'}>It looks like you have not set up your environment variables for this demonstration.</span> Please reach out to us <a href="http://near.chat" target="_blank">on Discord</a> for help. Otherwise, please use the button below to see how an oracle request is made and fulfilled.</p>
+                      <p className={'warning'}><strong>Warning</strong>: <span className={'warning-text'}>it looks like you have not set up your environment variables for this demonstration.</span> Thank you for the interest in this project. Please reach out to us <a href="http://near.chat" target="_blank">on Discord</a> for help. Otherwise, please use the button below to see how an oracle request <em>would be</em> made and fulfilled.</p>
                       : null
                 }
                 <button className="diagram-button" onClick={showDiagram}>Show Diagram</button>

--- a/src/components/DiagramOverlay.jsx
+++ b/src/components/DiagramOverlay.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 import '../styles/diagramOverlay.css'
 import { useDiagramDispatch } from './DiagramState'
 
@@ -11,6 +11,15 @@ const DiagramOverlay = () => {
         dispatch({type: 'displayDiagram'});
     }
 
+    const [isMissingEnvVars, setIsMissingEnvVars] = useState(false)
+
+    useEffect(() => {
+        if (typeof process.env.NEAR_ACCT === 'undefined' || process.env.NEAR_ACCT === '') {
+            setIsMissingEnvVars(true);
+        }
+    }, [])
+
+
     return (
         <div className="diagram-overlay">
             <div>
@@ -20,6 +29,11 @@ const DiagramOverlay = () => {
                 <p> 
                     Begin by selecting one of the token prices, then click on "Check" to initiate your request on the NEAR blockchain. Once the request is fulfilled, we will show you the Oracle process step-by-step.
                 </p>
+                {
+                    isMissingEnvVars ?
+                      <p className={'warning'}><strong>Warning</strong>: thank you for the interest in this project. <span className={'warning-text'}>It looks like you have not set up your environment variables for this demonstration.</span> Please reach out to us <a href="http://near.chat" target="_blank">on Discord</a> for help. Otherwise, please use the button below to see how an oracle request is made and fulfilled.</p>
+                      : null
+                }
                 <button className="diagram-button" onClick={showDiagram}>Show Diagram</button>
             </div>
         </div>

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -16,12 +16,17 @@ let near;
 let clientAcct;
 
 async function connectToNear() {
-  const keyStore = new keyStores.InMemoryKeyStore()
-  const keyPair = KeyPair.fromString(process.env.CLIENT_PRIVATE_KEY)
-  //sets key in memory
-  await keyStore.setKey(nearConfig.networkId, nearConfig.contractName, keyPair)
-  near = await connect(Object.assign({ deps: { keyStore } }, nearConfig))
-  return near;
+  // sets key in memory
+  if (nearConfig.contractName.endsWith('undefined') || nearConfig.contractName.substr(nearConfig.contractName.length -1) === '.') {
+    console.warn('Please make sure you have set environment variables NEAR_ACCT and CLIENT_PRIVATE_KEY')
+    return null;
+  } else {
+    const keyStore = new keyStores.InMemoryKeyStore()
+    const keyPair = KeyPair.fromString(process.env.CLIENT_PRIVATE_KEY)
+    await keyStore.setKey(nearConfig.networkId, nearConfig.contractName, keyPair)
+    near = await connect(Object.assign({ deps: { keyStore } }, nearConfig))
+    return near;
+  }
 }
 
 export async function getNear() {
@@ -30,8 +35,11 @@ export async function getNear() {
 
 //connect to contract using .env private key
 export async function initContract() {
-  clientAcct = await (await getNear()).account(near.config.contractName)
-  return clientAcct;
+  const initNear = await getNear();
+  if (initNear) {
+    clientAcct = await initNear.account(near.config.contractName)
+    return clientAcct;
+  }
 }
 
 export async function getClientAcct() {

--- a/src/styles/diagramOverlay.css
+++ b/src/styles/diagramOverlay.css
@@ -62,3 +62,6 @@ a:hover{
     cursor: pointer;
 }
 
+.warning .warning-text {
+    color: #FF585D;
+}


### PR DESCRIPTION
Basically if they haven't set the `NEAR_ACCT` we show a console warning as well as this:

<img width="883" alt="Screen Shot 2020-08-28 at 12 23 56 PM" src="https://user-images.githubusercontent.com/1042667/91607858-6f645a00-e929-11ea-9824-3762adf857a9.png">

Without this, the user will see a blank screen with a confusing console error from deep within near-api-js.